### PR TITLE
Update EMR default version

### DIFF
--- a/integration/emr/alluxio-emr.sh
+++ b/integration/emr/alluxio-emr.sh
@@ -260,7 +260,7 @@ main() {
   done
 
   if [[ -z "${alluxio_tarball}" ]]; then
-    alluxio_tarball="https://downloads.alluxio.io/downloads/files/2.0.0/alluxio-2.0.0-bin.tar.gz"
+    alluxio_tarball="https://downloads.alluxio.io/downloads/files/2.0.1/alluxio-2.0.1-bin.tar.gz"
   fi
 
   # Create user


### PR DESCRIPTION
Updating EMR default download to 2.0.1. Needs to be re-uploaded to s3://alluxio-public/emr/2.0.1/alluxio-emr.sh. Also need to update the emr-2.0.1 tag.